### PR TITLE
Block decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,11 @@ env/**
 texts/**
 .idea/**
 # }}}
+
+# Local development installs {{{
+*.egg-info/
+# }}}
+
+# Text editor cruft {{{
+*.swp
+# }}}

--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,5 @@ texts/**
 # }}}
 
 # Text editor cruft {{{
-*.swp
+*.sw[po]
 # }}}

--- a/blockspring/__init__.py
+++ b/blockspring/__init__.py
@@ -6,6 +6,8 @@ from mimetypes import MimeTypes
 import base64
 import re
 import tempfile
+import inspect
+import functools
 
 try:
     from urlparse import urlparse
@@ -205,6 +207,17 @@ def define(block):
 
 	response = Response()
 	block(request, response)
+
+def decorate(func):
+    @functools.wraps(func)
+    def block(request, response):
+        arguments = inspect.getargspec(func).args
+        parameters = tuple(request.params[arg] for arg in arguments)
+        output = func(*parameters)
+        response.addOutput('output', output)
+        response.end
+
+    return block
 
 class Request:
 	def __init__(self):

--- a/blockspring/example.py
+++ b/blockspring/example.py
@@ -1,0 +1,25 @@
+import blockspring
+
+@blockspring.decorate
+def fibonacci(x):
+    """This will be the test function for our decorator"""
+    print "doing something"+x
+    x = int(x)
+    if x < 0:
+        raise ValueError('Must be greater than 0')
+    elif x == 0:
+        return 1
+    elif x == 1:
+        return 1
+    else:
+        return x*x 
+
+
+def blibonacci(request, response):
+    x = request.params['x']
+    output = fibonacci(x)
+    response.addOutput('output', output)
+    response.end()
+
+    
+blockspring.define(fibonacci)

--- a/blockspring/test_decorators.py
+++ b/blockspring/test_decorators.py
@@ -1,0 +1,45 @@
+import pytest
+import blockspring
+
+# ***** Fixtures ****** #
+
+def decorator_fixture(a,b=0):
+    """This will be the test function for our decorator"""
+    return a+b
+
+def block_fixture(request, response):
+    mySum = request.params["num1"] + request.params["num2"]
+    response.addOutput('sum', mySum)
+    response.end()
+
+@pytest.fixture
+def request():
+    request = blockspring.Request()
+    return request
+
+@pytest.fixture
+def response():
+    response = blockspring.Response()
+    return response
+
+@pytest.fixture
+def wrapped():
+    wrapped = blockspring.decorate(decorator_fixture)
+    return wrapped
+
+########## Tests #########
+
+def test_decorator_respects_name(wrapped):
+    assert wrapped.__name__ == 'decorator_fixture'
+
+def test_creates_blockspring_function(wrapped,request, response):
+    assert response.result['_blockspring_spec']==True
+    
+
+def test_adds_output(wrapped, request, response):
+
+    request.addHeaders({'b':1, 'c':3}) #<--this doesn't work
+    test = wrapped(request, response)
+    assert response.response['output']==4
+    pass
+


### PR DESCRIPTION
I added a decorator function to the module. This function should help avoid boilerplate code. 
Imagine that a user has a function:

    def foo(bar):
        return bar

They can now copy that _directly_ into blockspring by simply using the decorator:

    @blockspring.decorate
    def foo(bar):
        return bar
    blockspring.define(foo)

**No need to change the function name, arguments or add blockspring boilerplate code**! 
The decorator will find the names of the arguments and transform `foo` into:

    def foo(request, response):
        bar = request.params['bar']
        output = foo(bar)
        response.addOutput('output', output)
